### PR TITLE
Add MONGODB_REQUIRE_TLS=False for local dev environments

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,7 @@ services:
       ENABLE_DROP_DATABASE: True
       API_PORT: 8081
       SPA_PORT: 8082
+      MONGODB_REQUIRE_TLS: False
     depends_on:
       mongodb:
         condition: service_healthy


### PR DESCRIPTION
- Update docker-compose.yaml to set MONGODB_REQUIRE_TLS=False for configurator_api service